### PR TITLE
Fix chmod error on Unix

### DIFF
--- a/QPM/Utils.cs
+++ b/QPM/Utils.cs
@@ -40,7 +40,7 @@ namespace QPM
                 : new ProcessStartInfo
                 {
                     FileName = "/bin/bash",
-                    Arguments = "-c \"chmod +rw --recursive '" + absPath + "'\"",
+                    Arguments = "-c \"chmod -R +rw '" + absPath + "'\"",
                     UseShellExecute = false,
                     CreateNoWindow = true
                 };


### PR DESCRIPTION
I installed this on my Mac and got a heap of `chmod: --recursive: No such file or directory` messages when I ran `qpm restore`. I looked through the code and I'm pretty sure this is the reason. There is no `--recursive` flag on the Unix chmod (it's `-R`) and it must come before the permissions argument.