### PR TITLE
Versioning the cache so we can symlink

### DIFF
--- a/QPM/Providers/RemoteQPMDependencyResolver.cs
+++ b/QPM/Providers/RemoteQPMDependencyResolver.cs
@@ -107,7 +107,7 @@ namespace QPM
                 // This may not always be the case
                 try
                 {
-                    var proc = new ProcessStartInfo("git", $"clone -b {branchName} {url}.git {downloadFolder} --recurse-submodules --no-tags")
+                    var proc = new ProcessStartInfo("git", $"clone -b {branchName} {url}.git {downloadFolder} --recurse-submodules --no-tags --depth 1")
                     {
                         CreateNoWindow = true,
                         RedirectStandardOutput = true,

--- a/QPM/Providers/RemoteQPMDependencyResolver.cs
+++ b/QPM/Providers/RemoteQPMDependencyResolver.cs
@@ -183,10 +183,9 @@ namespace QPM
                     if (Directory.Exists(dest))
                         Utils.DeleteDirectory(dest);
 
-
                     // Create parent directories
-                    Utils.CreateDirectory(dest);
-                    Utils.DeleteDirectory(dest);
+                    Utils.CreateDirectory(dst);
+
 
                     Utils.SymLinkOrCopyDirectory(location, dest);
                 }
@@ -495,6 +494,8 @@ namespace QPM
                 var url = conf.Config.Info.Url;
                 var outter = Utils.GetTempDir();
 
+                // QPM_CacheV2/ depId / version
+                // Example: QPM_CacheV2 / codegen / 0.8.1
                 var downloadFolder = Path.Combine(outter,conf.Config.Info.Id, conf.Config.Info.Version.ToString());
 
                 if (!Directory.Exists(downloadFolder))

--- a/QPM/Providers/RemoteQPMDependencyResolver.cs
+++ b/QPM/Providers/RemoteQPMDependencyResolver.cs
@@ -201,13 +201,11 @@ namespace QPM
             var src = Path.Combine(root, sharedConfig.Config.SharedDir);
             if (!Directory.Exists(dst) || !Utils.FolderHash(src).SequenceEqual(Utils.FolderHash(dst)))
             {
-                if (Directory.Exists(dst))
-                    Utils.DeleteDirectory(dst);
                 Console.WriteLine($"Copying: {src} to: {dst}");
 
-                // Create parent directories
-                Utils.CreateDirectory(dst);
-                Utils.DeleteDirectory(dst);
+                if (!Directory.Exists(baseDst))
+                    // Create parent directories
+                    Utils.CreateDirectory(baseDst);
 
 
                 Utils.SymLinkOrCopyDirectory(src, dstExpanded);

--- a/QPM/SymLinker/LinkCreators/WindowsSymLinkCreator.cs
+++ b/QPM/SymLinker/LinkCreators/WindowsSymLinkCreator.cs
@@ -14,10 +14,26 @@ namespace SymLinker.LinkCreators
             IntPtr lpSecurityAttributes
         );
 
+        [DllImport("Kernel32.dll", CharSet = CharSet.Unicode )]
+        static extern bool CreateSymbolicLink(
+            string lpFileName,
+            string lpExistingFileName,
+            IntPtr lpSecurityAttributes
+        );
+
         public bool CreateSymLink(string source, string dest, bool file)
         {
             var symbolicLinkType = file ? SymbolicLink.File : SymbolicLink.Directory;
-            return CreateHardLink(dest, source, (IntPtr) symbolicLinkType);
+            switch (symbolicLinkType)
+            {
+                case SymbolicLink.File:
+                    return CreateHardLink(dest, source, IntPtr.Zero);
+                // TODO: This doesn't work, we'll need to work on it
+                case SymbolicLink.Directory:
+                    return CreateSymbolicLink(dest, source, (IntPtr) symbolicLinkType);
+            }
+
+            return false;
         }
 
         private enum SymbolicLink


### PR DESCRIPTION
Still no symlinks for dirs on Windows without admin, sad)

However this does address a few things:
- No more redownloading headers for different versions
- SO files with `overrideSoName` are now symlinked
- A new cache folder is used to avoid potential issues with the old (can be deleted with `qpm cache clear`)
- Unnecessary copying and redownloading of libraries already in `extern` 
- Git cloning does not clone tags, should this be extended with git history too using shallow? It is unnecessary to have the entire repo when you only need the headers.